### PR TITLE
Copy files from cubic repo and old cobalt-client wiki

### DIFF
--- a/docs/C_API/ASR-Web-API.md
+++ b/docs/C_API/ASR-Web-API.md
@@ -1,0 +1,149 @@
+# Entry points
+
+There are two entry points: /api, and /recognize. The /api entry point is used to create and delete objects with state and query attributes. The /recognize entry point is used to send audio, send events to control recognition, and retrieve results. All requests to the API are POST, and all successful returns are JSON.
+
+# Stateless Example
+
+The following is a stateless example, where we start and finish a recognition in a single API call by sending a .wav file to the recognize entry point. Note that this entry point only accepts 16 KHz, 16 bit sampled, mono .wav files.
+
+```
+$ curl  --data-binary @<wav audio> -H "event-type: file"  -H"file-type: wav" <url>
+{
+   "message":"returning results",
+   "results":[
+      {
+         "status":"final",
+         "version":"1",
+         "cobalt_object":"stt_result",
+         "features":null,
+         "nbest":[
+            [
+               {
+                  "confidence":1000,
+                  "type":"token",
+                  "features":null,
+                  "value":"hello"
+               },
+               {
+                  "confidence":1000,
+                  "type":"token",
+                  "features":null,
+                  "value":"world"
+               }
+            ]
+         ]
+      }
+   ]
+}
+```
+
+There are two possible outcomes of each file based API call are: no result is ready, or results are ready. The key "results" will exist if results ready. Because there may be multiple utterances per audio file, we return results as a list of stt_results, where each item of the list represents an utterance, and all items are in temporal order. See [[Results-Object-Model|Results Object Model]] for details on the stt_results format.
+
+# /api entry point
+
+The /api entry point contains API calls that create and delete recognizer objects containing state and query models for various state. The /api entry point accepts JSON formatted text data in the body. The JSON payload must contain the key "type". The following table lists the different types.
+
+| type | required key(s) | description | return on success
+|--- | --- | --- | ---
+| get-model-attributes | model-id | get the attributes of a model | JSON object with key/value configuration pairs
+| create-recognizer | model-id (uses default if no key provided) | creates a recognizer on the server | JSON object with 'recognizer-id'
+| create-extended-recognizer | model-id (uses default if no key provided) | creates a long running recognizer on the server | JSON object with 'recognizer-id'
+| delete-recognizer | recognizer-id | deletes a recognizer | JSON with message
+
+
+### get-model-attributes
+
+```
+$ curl -X POST -H "Content-type: application/json" \
+      -d '{"type": "get-model-attributes", "model-id": "test-model"}' \
+      http://localhost:8888/api
+{"sample-rate": 8000, "bits-per-sample": 16}
+```
+
+### create-recognizer
+```
+$ curl -X POST -H "Content-type: application/json" \
+      -d '{"type": "create-recognizer", "model_id": "test-model"}' \
+      http://localhost:8888/api
+{"recognizer-id": "8d24725c-5b06-11e5-892c-a45e60f06c45"}
+```
+
+### delete-recognizer
+```
+$ curl -X POST -H "Content-type: application/json" \
+      -d '{"type": "delete-recognizer", "recognizer-id": "8d24725c-5b06-11e5-892c-a45e60f06c45"}' \
+      http://localhost:8888/api
+{"message": "deleted recognizer 8d24725c-5b06-11e5-892c-a45e60f06c45"}
+```
+
+# /recognize entry point
+The /recognize entry point expects information in the header, each request header must hold the key "event-type". The body (payload) should be binary audio data. The following table lists the different types of requests. Note that we've already shown the state-less API call above.
+
+| event-type | required key(s) | description | body required | return on success
+|--- | --- | --- | --- | ---
+| file | file-type | stateless file based interaction | yes, binary wav file | JSON with list of stt_results in "results" key
+| streaming-audio | recognizer-id | stream audio from the same speaker/device, a chunk at a time | yes, binary PCM | JSON with message
+| clear-audio-queue | recognizer-id | returns when recognizer finishes processing audio | no | JSON with message
+| end-session | recognizer-id | ends the recognition session, publishes result if available | no | JSON with message
+| get-result | recognizer-id | gets recognition results for current recognizer | no | JSON with list of some kind of result in "results" key
+| get-final-result | recognizer-id | combines clear-audio-session, end-session, get-result, returns all results, this call saves some round trip network latency, if the client is sure that it is done sending audio (client-side endpointing) | no | JSON with list of some kind of result in "results" key
+Note that the results key returned by the get-result and get-final-result calls will contain [[Results-Object-Model|Results Object Model]] for stt_results.
+# Streaming audio API
+
+## Motivations, implementation, and workflow
+
+Opening an entry point to allow streaming audio allows clients to push audio as soon as it is available. This allows the cloud-based engine to initialize computationally heavy machine learning algorithms only once, which decreases the latency of each subsequent API call. 
+
+The following example uses Python's [requests](http://docs.python-requests.org/en/master/) package to illustrate making streaming API calls. Streaming audio requires session persistence, so please send server side cookies back if you plan to use the streaming audio API. Please contact Cobalt for our client library to see the full code.
+
+
+## Example
+```python
+
+# we must make sure these calls hit the same backend server, so we use the sessions object to handle server cookies.
+requests_obj = requests.Session()
+
+# send request to /api entry point to create recognizer
+recognizer_id = send_create_recognizer(api_url, requests_obj=requests_obj, verbose=verbose)
+
+# send data a chunk at a time.
+while begin_index < len(data):
+    if begin_index + chunk - 1 <= len(data):
+        end_index = begin_index + chunk
+    else:
+        end_index = len(data)
+    send_stream_audio(requests_obj, recognize_url, recognizer_id, data[begin_index:end_index], verbose=verbose)
+    begin_index += chunk
+
+# send_stream_audio() is a non-blocking call, so we call clear_audio_queue to make sure it processed all the audio 
+# an alternative is to make periodic calls with send_get_result() until we get an actionable result.
+send_clear_audio_queue(requests_obj, recognize_url, recognizer_id, verbose=verbose)
+
+# if the model does not 'end-point', this call forces an 'end-point'.
+send_end_session(requests_obj, recognize_url, recognizer_id, verbose=verbose)
+
+# get the result
+results = send_get_result(requests_obj, recognize_url, recognizer_id)
+send_delete_recognizer(api_url, recognizer_id, requests_obj=requests_obj, verbose=verbose)
+```
+
+## Long Audio Files
+
+A special use case for the streaming mode is to decode very long audio files (a few minutes or longer). The key idea is to break up the long file into chunks and stream them into the server in synchronous mode. As each chunk is streamed to the server, the client should check for results, which will become available whenever end-points are reached. Note that the model must support end-pointing for the long audio file support to work. This special recognizer is created with the `create-extended-recognizer` type call against /api:
+
+```Python
+requests_obj = requests.Session()
+recognizer_id = send_create_recognizer(api_url, recognizer_construct, is_extended=True, requests_obj=requests_obj)
+
+results = []
+for chunk in wav_file_iter(audio_filepath):
+    send_stream_audio(requests_obj, recognize_url, recognizer_id, chunk)
+    try:
+        result = send_get_result(requests_obj, recognize_url, recognizer_id, expected_message='returning results')
+        results.append(result)
+    except Exception:
+        pass
+
+send_end_session(requests_obj, recognize_url, recognizer_id)
+send_delete_recognizer(api_url, recognizer_id, requests_obj=requests_obj)
+```

--- a/docs/C_API/Demo-Configurations-Available.md
+++ b/docs/C_API/Demo-Configurations-Available.md
@@ -1,0 +1,23 @@
+The following configurations are currently available in the demo:
+
+| Identifier | Configuration |
+|------------|---------------|
+| (A) US English (16KHz WAV audio)|available in online demo|
+| (B) US English (8KHz WAV audio)|available in online demo|
+| asr-model  | default for on-premises demo       |
+| asr-model-with-stats | outputs confusion network (on premises) |
+| spanish-asr-model | Spanish ASR (on premises) |
+
+
+
+You can switch between configurations using the --list_file parameter of the client.  For example:
+```
+python ./py/client.py  --url <endpoint> --list_file True ./audio/hello_world.list
+```
+
+The file referenced by the --list_file parameter (./audio/hello_world.list in this case) has the following json form:
+```
+{"audio_path": "hello_world_16khz.wav", "model_id":"asr-model-with-stats"}
+```
+
+The "model_id" field identifies which of the above configurations to use.

--- a/docs/C_API/Design-Goals.md
+++ b/docs/C_API/Design-Goals.md
@@ -1,0 +1,5 @@
+**Extensibility**: 
+Cobalt runtime may have clients that want to augment the information returned in this structure. We will push additional information to the "features" key, at both the "hypothesis" and "token" level, instead of altering the structure of this basic object.
+
+**Backward Compatibility**: 
+As much as possible, we look to not change the structure of this JSon, as we will be dealing with client code that may or may not be updated. 

--- a/docs/C_API/Home.md
+++ b/docs/C_API/Home.md
@@ -1,0 +1,23 @@
+**Welcome to the Cobalt Client Wiki!**
+
+See the links to the right to navigate.
+
+This package contains client code and API documentation for Cobalt's ASR (automatic speech recognition) service. Cobalt will provide interested customers an endpoint URL for a demo ASR model to use with this client package. Please contact us at http://cobaltspeech.com/contact-us.html to obtain it and use that URL whenever this documentation includes the <URL> placeholder.
+
+The demo service is not meant to serve as part of any production system. There are no performance or support service level agreements for this service. While our goal is to provide a stable interface, Cobalt reserves the right to change the API and endpoint URL at any time. The demo recognizes 16khz mono-channel audio, sent as 16 bit PCM samples. It is for general conversational uni-speaker English and will perform best with a close-range mic and limited background noise. Please contact us at (http://cobaltspeech.com/contact-us.html) if you are interested in different audio formats, a production quality service, domain/application-specific models with improved accuracy/speed, other languages, speaker diarization, or any customization.
+
+The web APIs can be called directly using curl or Postman or any similar tool. Or clone this repository to run a sample client application.  
+
+Requirement: This package requires python2.7, and the requests package: http://docs.python-requests.org/en/master/ The py/client directory contains an example python client. You will need to install python's requests module to use the example client.
+
+See the links on the right of this page for documentation on how to use this client with our API and result objects: "ASR Web API", "Demo Configurations Available", "Result Objects Model".
+
+The audio directory contains a single 16khz audio file.
+
+Run the client as:
+```
+python py/client.py audio/hello_world_16khz.wav --url http://<URL>
+```
+Expected results:
+
+{"message": "returning results", "results": [{"status": "partial", "version": "1", "cobalt_object": "stt_result", "features": null, "nbest": [{"confidence": 1000, "hypothesis": [{"confidence": 1000, "type": "token", "features": null, "value": "Hello"}]}]}, {"status": "final", "version": "1", "cobalt_object": "stt_result", "features": null, "nbest": [{"confidence": 1000, "hypothesis": [{"confidence": 1000, "type": "token", "features": null, "value": "Hello"}, {"confidence": 1000, "type": "token", "features": null, "value": "World"}]}]}]}

--- a/docs/C_API/README.md
+++ b/docs/C_API/README.md
@@ -1,0 +1,59 @@
+# Deprecated C API
+### NOTE: this C API has been deprecated in favor of the [gRPC API](https://github.com/cobaltspeech/client).  This documentation is provided to support legacy clients.
+
+This document provides an overview of the API for the Cobalt ASR engine. We begin with an overview of the tenets of the API, tour a few API entry points, proceed to show an example workflow, and wrap up by discussing the result object model.
+
+**Api tenets:**
+
+This is a thread-safe speech recognition API.
+
+The objective of this API is to convert speech to text.
+
+There are two main types of 'objects' in this API: Models and Recognizers.
+
+A Model is an encapsulation for machine-learned artifacts that were trained in offline, supervised fashion. Models are the 'brain' of our system. Models own the accuracy of recognition.
+
+A Recognizer is created from a model and contains the logic for performing speech recognition. Recognizers own the latency and stability of recognition.
+
+Models are typically heavy weight objects that should be created once and used often. Recognizers are light weight objects should be created per audio stream (unless otherwise advised).
+
+This API provides two main classes of functions: API level functions, prefixed by API_, are responsible for creating and deleting objects, such as models and recognizers. Object specific functions, prefixed by object names such as Recognizer_, are responsible for controlling specific functionality of each object, such as pushing audio to a recognizer.
+
+Each API call returns success or failure. If the call is successful, the object created for the API call may be used; if the call failed, the reason for failure is documented in the return struct.
+
+The API is stateful, and uses string (char*) based IDs to maintain state; e.g. clients create a Models and control the ID of the model by setting modelIdC, that model may then be used by calling other API functions with the same ID.
+
+Memory management is crucial to the success of the API, the client must make sure each pointer object passed to an API call remains in scope until the call returns. Pointers returned by the API will remain in scope until the client calls the "clear" function. Best practice is to copy the contents of each pointer, and call clear() immediately, to avoid memory usage growth.
+
+The API delivers objects via callbacks, e.g. logging, metrics, and results.
+
+Callbacks are registered as function pointers. The registration calls are not thread-safe. Best practice is to registered each callback once at the start of the process. Callbacks should be registered prior to any other API calls.
+
+The API delivers per-recognition results in asynchronous fashion. To allow the client to map a result to a recognizer, the result (and metrics) callbacks contain a field for the id of the recognizer. Each recognizer object delivers (0+) results per lifetime, depending on the underlying model and Recognizer_ API calls.
+
+**Tour of API Entry Points**
+
+[cubic.h](https://github.com/cobaltspeech/cubic/blob/master/cpp/api/cubic.h)
+
+**API workflow example**
+
+[exampleWorkflow.cpp](https://github.com/cobaltspeech/cubic/blob/master/cpp/client/example_workflow.cpp)
+
+**Recognizer construct**
+
+In the New Recognizer call: Api_NewRecognizer(recognizerId.c_str(), modelId.c_str()), the second parameter may be a string representing a model-id, or a JSon string object that represents a model, a model-domain, a recognizer-type, and a transcript.
+
+Here is the full JSon:
+
+| key | value|
+|---|---|
+| modelset_id | identifies a modelset, required parameter if construct is JSon.|
+| recognizer_type | type of recognizer, defaults to 'asr', optional.|
+| model_domain | domain of model, identified by modelset_id, defaults to default domain, optional.|
+| transcripts | required for models/recognizers like limited_vocab, optional for asr recognizers.|
+
+
+
+**Result object model**
+
+The result object model is JSON, and described in detail [[ Results-Object-Model.md ]]

--- a/docs/C_API/Results-Object-Model.md
+++ b/docs/C_API/Results-Object-Model.md
@@ -1,0 +1,151 @@
+This page documents the Cobalt Runtime results object model. The goal of the design is to create an object model that is intuitive, is programming language agnostic, yet extensible to future iterations.
+
+The object model is encoded in JSON, making the object agnostic and easily accessible across modern languages. Clients of Cobalt Runtime may transmit this model across machines as-is, or wrap this model in additional JSON structures.
+
+**Top Level Structure**: the top level structure of the JSON contains these fields
+
+```
+{
+    "version": "1", 
+    "features" : {},
+    "cobalt_object": "stt_result", 
+    "status": "final",
+    "nbest": []
+    "confusion_net":[]
+}
+```
+The value "stt_result" denotes that this is a speech-to-text result.
+
+The **Nbest structure** is a list, with an item in the list taking the following form:
+```
+       {
+           "confidence": 1000,
+           "features": {},
+           "hypothesis": [
+                {
+                    "confidence": 1000, 
+                    "type": "token", 
+                    "features": {}, 
+                    "value": "let's"
+                }, 
+                {
+                    "confidence": 1000, 
+                    "type": "token", 
+                    "features": {}, 
+                    "value": "recognize"
+                }, 
+                {
+                    "confidence": 1000, 
+                    "type": "token", 
+                    "features": {}, 
+                    "value": "speech"
+                }
+            ]
+       },
+```
+The key "hypothesis" holds the textual contents of the result in the form of a list, it representing all the tokens, information about those tokens, that made up this result; the "features" key is an optional field, which may hold optional information relating to the entire hypothesis; the "confidence" key holds the confidence score for this hypothesis, it is an integer of range 0-1000.
+
+**Hypothesis Features**
+The features field associated with each item in the Nbest list may optionally include additional information such as perplexity.
+Here is a list of feature fields:
+
+| Feature       | Value       | Explanation |
+| ------------- |-------------|-------------|
+| perplexity    | float       | Perplexity calculated given the hypothesis and grammar FST provided in the config file |
+
+Each element of the "hypothesis" list holds the keys "confidence", an integer score of range 0-1000; "value", the text of the result, "type", the type of the element, and "features", an optional field to hold additional information.
+
+Here is a full example of an "stt_result" structure: [Full result example](stt_result_structure.md)
+
+**Empty Results**: When a result is empty, no json is output. (Use the session_end logging callback if you need to determine whether processing has finished.)
+
+**Semantic Tagging** In addition to tokens, models have the ability to tag a group of tokens with some action or intent:
+
+<goto> navigate to </goto> <street_address> five four four one </street_address>
+
+As the example shows, the tags <goto> and </goto> surround the tokens "navigate to". We are following XML conventions here and using "/" to denote the end of a tag.
+
+We will work to define a limited set of actionable tags with the end-customer(s).
+
+Here is the JSON representation of tagging:
+
+```
+           "hypothesis": [
+                {
+                    "type": "tag", 
+                    "value": "<goto>"
+                }, 
+                {
+                    "confidence": 1000, 
+                    "type": "token", 
+                    "features": {}, 
+                    "value": "navigate"
+                }, 
+                {
+                    "confidence": 1000, 
+                    "type": "token", 
+                    "features": {}, 
+                    "value": "to"
+                }
+                {
+                    "type": "tag", 
+                    "value": "</goto>"
+                }, 
+            ],
+```
+Notice that tags do not have the confidence, or features keys.
+
+**Token Features**
+The features field associated with each token may optionally include additional information such as timestamps.
+Here is a list of feature fields:
+
+| Feature       | Value       | Explanation |
+| ------------- |-------------|-------------|
+| begin_ms      | integer | Start time (in milliseconds) of a token, relative to the beginning of a recognizer instance
+| duration_ms   | integer | Duration (in milliseconds) of a token |
+
+Here is an example for timestamps:
+```
+           "hypothesis": [
+                {
+                    "confidence": 1000, 
+                    "type": "token", 
+                    "features": {"begin_ms":0,"duration_ms":290}, 
+                    "value": "let's"
+                }, 
+                {
+                    "confidence": 1000, 
+                    "type": "token", 
+                    "features": {"begin_ms":290,"duration_ms":840}, 
+                    "value": "recognize"
+                }, 
+                {
+                    "confidence": 1000, 
+                    "type": "token", 
+                    "features": {"begin_ms":1130,"duration_ms":590}, 
+                    "value": "speech"
+                }
+            ],
+```
+
+**Confusion Network**
+The json output that represents a confusion network consists of a sequence of links, where each link groups a set of alternate arcs or tokens. Each link is associated with beginning and ending timestamps, which are overall average begin/end times for the set of tokens in a link.
+
+Link:
+```
+{
+"begin_ms":0,
+"duration_ms":0,
+"arcs":[]  //list of token-structs
+}
+```
+Arc (token struct):
+```
+{
+"confidence": 1000
+"value": "let's"
+}
+```
+
+Again, see a full example of an "stt_result" structure, including a confusion network, at: [Full result example](stt_result_structure.md)
+

--- a/docs/C_API/STT-metrics.md
+++ b/docs/C_API/STT-metrics.md
@@ -1,0 +1,78 @@
+Cobalt’s recognizer emits a speech-to-text metric, named “stt_metrics”, for every recognition result. These metrics are designed to report and diagnose the latency of said recognition. 
+
+**Latency measuring metrics**
+
+Definition of Latency:
+
+We define and measure latency as the difference in time from when the customer finished speaking, termed “end-of-speech”, to when we emitted the result. 
+
+Metrics:
+
+Below is a list of our metrics focused on measuring and breaking latency to actionable buckets.
+
+| Metric Name | Description
+| --- | ---
+|stt_latency_msec | The engine’s best guess on the latency the customer experiences for this utterance.
+|delivery_latency_msec | Amount of latency attributable to how the customer delivered audio.
+|endpoint_latency_msec | Amount of latency attributable to how much time we spent detecting end-of-speech.
+
+
+**Diagnostic metrics:**
+
+In addition to the top level latency metrics, the engine publishes a set of metrics to aid in diagnosing or alarming on what causes abnormal latency values:
+
+|Metric name	| Description
+| --- | ---
+| total_wall_clock_processing_msec	|Total time spent by the engine in processing audio.
+| total_audio_processed_msec | 	Total amount of audio processed.
+|scoring_time_ratio| Ratio of audio time to time spent evaluating the DNN acoustic model, multiplied by 1000 and normalized to integer space;  e.g. value of 2000 means the engine spent 2 seconds processing every second of audio.
+|search_time_ratio | Same as scoring_time_ratio except this ratio measure time to execute the Viterbi search algorithm.
+| cputime_audio_ratio | 	Ratio of audio to compute time.  It should be noted that this ratio tallies all time spent on all CPUs (even in parallel).  So when the model uses search.on_separate_thread to run the scoring and search on separate processors, this value will look much higher than it would with them on the same processor even though the overall latency introduced by processing time may be lower.
+| result_building_latency_msec |	The amount of time spent building a result.
+| recognizer_startup_cputime_msec |	The amount of time spent starting up the recognizer.
+| callbacks_msec | The amount of time we spent *in* callbacks.
+| audio_delivery_ratio | Ratio of the amount of audio processed and delivery time of that audio; e.g.  if the value is 2000, then 1 second of audio was delivered in 0.5 seconds.
+| fe_processing_msec | The amount of time we spent in the frontend.
+| active_recognizers_count | The number of recognizers active, when the current recognizer was constructed, includes the current recognizer.
+| metrics_building_msec | The amount of time spent calculating the metrics values.
+| wait_time_per_processor | A map of threaded processor name to how much time it spent waiting for data to process in milliseconds.
+
+**Effect of previous utterances:**
+
+We define all audio delivered via a singular customer interaction as a “stream”. This stream of audio may be broken up into several “utterances”. The state of recognition for previous utterances matter in our metrics for the current utterance: e.g. what happens in utterance-0 may carry over to utterance-1.
+
+It is illustrative to consider a dummy example:
+
+1.	We incur a latency of 3 seconds on utterance-0 due to high cputime_audio_ratio
+2.	We have real-time processing, it takes us 1 second to process 1 second of audio, for utterance-1.
+3.	Our latency for utterance-1 is still 3 seconds.
+
+In this scenario, the engine never caught up to the audio being pushed, and the second utterance in the stream maintains the 3 second latency number, even though we were real-time processing the second utterance. 
+
+**Metrics Object Model and emission:**
+
+The engine emits metrics via a callback. The metrics are emitted in JSON form, with the following top-level format:
+
+
+```
+{
+    "cobalt_object": "stt_metrics",
+    "metrics": <see next section>
+    "version": "1"
+}
+```
+
+The “metrics” key points to a map<string, int> structure of metrics. The metrics are:
+
+
+```
+    "metrics": {
+        "callbacks_msec": 0,
+        "cputime_audio_ratio": 723,
+        "recognizer_startup_cputime_msec": 55,
+        "result_building_latency_msec": 2,
+        "stt_latency_msec": 1358,
+        "total_audio_processed_msec": 1936,
+        "total_wall_clock_processing_msec": 1401
+    },
+```

--- a/docs/C_API/stt_result_structure.md
+++ b/docs/C_API/stt_result_structure.md
@@ -1,0 +1,162 @@
+```
+{
+  "message": "returning results",
+  "results": [
+    {
+      "status": "partial",
+      "version": "1",
+      "cobalt_object": "stt_result",
+      "features": null,
+      "nbest": [
+        {
+          "confidence": 1000,
+          "features": null,
+          "hypothesis": [
+            {
+              "confidence": 1000,
+              "type": "token",
+              "features": null,
+              "value": "Hello"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "status": "final",
+      "features": null,
+      "version": "1",
+      "cobalt_object": "stt_result",
+      "nbest": [
+        {
+          "confidence": 1000,
+          "features": {
+              "perplexity": 30.0
+          },
+          "hypothesis": [
+            {
+              "confidence": 1000,
+              "type": "token",
+              "features": {
+                "duration_ms": 330,
+                "begin_ms": 660
+              },
+              "value": "Hello"
+            },
+            {
+              "confidence": 1000,
+              "type": "token",
+              "features": {
+                "duration_ms": 600,
+                "begin_ms": 990
+              },
+              "value": "World"
+            }
+          ]
+        }
+      ],
+      "confusion_network": [
+        {
+          "duration_ms": 654,
+          "begin_ms": 0,
+          "object_name": "link",
+          "arcs": [
+            {
+              "confidence": 1000,
+              "value": "<eps>"
+            }
+          ]
+        },
+        {
+          "duration_ms": 317,
+          "begin_ms": 654,
+          "object_name": "link",
+          "arcs": [
+            {
+              "confidence": 450,
+              "value": "HELLO"
+            },
+            {
+              "confidence": 203,
+              "value": "OH"
+            },
+            {
+              "confidence": 170,
+              "value": "A"
+            },
+            {
+              "confidence": 106,
+              "value": "THE"
+            },
+            {
+              "confidence": 34,
+              "value": "THOUGH"
+            },
+            {
+              "confidence": 15,
+              "value": "LOW"
+            },
+            {
+              "confidence": 12,
+              "value": "FOR"
+            },
+            {
+              "confidence": 6,
+              "value": "LITTLE"
+            },
+            {
+              "confidence": 3,
+              "value": "O"
+            }
+          ]
+        },
+        {
+          "duration_ms": 5,
+          "begin_ms": 971,
+          "object_name": "link",
+          "arcs": [
+            {
+              "confidence": 973,
+              "value": "<eps>"
+            },
+            {
+              "confidence": 12,
+              "value": "THE"
+            },
+            {
+              "confidence": 8,
+              "value": "LOW"
+            },
+            {
+              "confidence": 6,
+              "value": "LITTLE"
+            }
+          ]
+        },
+        {
+          "duration_ms": 613,
+          "begin_ms": 977,
+          "object_name": "link",
+          "arcs": [
+            {
+              "confidence": 1000,
+              "value": "WORLD"
+            }
+          ]
+        },
+        {
+          "duration_ms": 500,
+          "begin_ms": 1590,
+          "object_name": "link",
+          "arcs": [
+            {
+              "confidence": 1000,
+              "value": "<eps>"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```

--- a/docs/ModelConfigOptions.md
+++ b/docs/ModelConfigOptions.md
@@ -1,0 +1,213 @@
+### Config Option Documentation
+
+
+#### Debug options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| debug.save_lattices | Whether we save a lattice | bool | 0 |
+| debug.save_lattices_path | Directory where we save the lattices | path string | "" |
+
+
+
+#### Endpoint options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| endpoint.type | Type of endpointer ("all_speech", "rule_based", "kaldi_online", or "keyword") | string | "all_speech" |
+| endpoint.silence_phone_string | String of silence phonemes | string | "" |
+| endpoint.must_reach_final | Whether utterance must be in a final state to be endpointed | bool | 1 |
+| endpoint.must_contain_non_silence | Whether utterance must contain non-silence to be endpointed | bool | 1 |
+| endpoint.trailing_silence_frames | Minimum number of trailing silence frames to endpoint | int | 10 |
+| endpoint.max_relative_cost | Maximum relative cost | float | 100 |
+| endpoint.mininum_utterance_length_frames | Minimum length of an utterance before we end-point | int | 10 |
+| endpoint.max_silence_frames | Maximum number of allowed trailing silence frames before endpoint, used only if endpointer.type is keyword | int | 75 |
+| endpoint.kaldi_online_endpointer_config | Filepath for kaldi's online endpointer configs, used only if endpointer.type is kaldi-online. | path string | "" |
+
+
+
+#### Front End Options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| fe.acoustic_sampling_rate_hz | Sampling rate for audio, the model should be tuned to this sampling rate. Behavior is undefined if audio of mis-matched sampling rate is pushed to the engine. 8000 means 8kHz. | float | 8000 |
+| fe.input_sampling_rate_hz | Sampling rate of the incoming audio; default 0 means no resampling needed | float | 0 |
+| fe.frame_shift_ms | Frame shift in milliseconds | float | 10.0 |
+| fe.frame_length_ms | Frame length in milliseconds | float | 25.0 |
+| fe.dither | Dithering amount, use 0.0 to disable dithering | float | 1.0 |
+| fe.preemph_coeff | Preemphasis Coefficient | float | 0.97 |
+| fe.remove_dc_offset | If true, subtract the wave mean before taking the FFT | bool | 1 |
+| fe.round_to_pow_2 | If true, round the window size up to the next power of 2 | bool | 1 |
+| fe.blackman_coeff | Blackman Coefficient to use | float | 0.42 |
+| fe.snip_edges | If true, fit all frames completely into the waveform | bool | 1 |
+| fe.window_type | What windowing algorithm to use. May be "hamming", "rectangular", "povey", "hanning", or "blackman" | string | "povey" |
+| fe.num_cepstrals | Number of cepstra in MFCC computation (including C0) | int | 13 |
+| fe.use_energy | Use energy (not C0) in MFCC computation | bool | 1 |
+| fe.cepstral_lifter | Constant that controls scaling of features | float | 22.0 |
+| fe.num_mel_bins | Number of triangular mel-frequency bins | int | 23 |
+| fe.mel_low_frequency | Low cutoff frequency for mel bins | float | 20.0 |
+| fe.mel_high_freq | High cutoff frequency for mel bins (if \< 0, offset from Nyquist) | float | 0.0 |
+| fe.feature_type | Type of feature. May be "plp", "mfcc", or "fbank" | string | "mfcc" |
+| fe.mel_energy_floor | Energy floor taking logs in mel energy, 0 to set it to std::numeric_limits\<float>::min() value | float | 0 |
+| fe.lpc_order | Order of LPC analysis in PLP computation | int | 12 |
+| fe.compress_factor | Compression factor in PLP computation | float | 0.333333 |
+| fe.cepstral_scale | Scaling constant in PLP computation | float | 1.0 |
+| fe.use_log_fbank | If true, produce log-filterbank, else produce linear. | bool | 1 |
+| fe.use_power | If true, use power, else use magnitude | bool | 1 |
+| fe.random_generator_seed | The seed value for generating random numbers | int | 0 |
+| fe.random_pool_size | The number of random ints that will be generated using the random number seed | int | 50000 |
+| fe.use_energy_vad | Use energy based voice activity detection | bool | 0 |
+| fe.vad_energy_threshold | Constant term in energy threshold for MFCC0 for VAD (also see fe.vad_energy_mean_scale) | float | 5.0 |
+| fe.vad_energy_mean_scale | The actual threshold is calculated as `vad_energy_mean_scale*m + vad_energy_threshold` where `m` is the mean log-energy of the file  | float | 0.5 |
+| fe.vad_frame_context | Number of frames of context on each side of central frame, in window for which energy is monitored | int | 5 |
+| fe.vad_proportion_threshold | Parameter controlling the proportion of frames within the window that need to have more energy than the threshold | float | 0.6 |
+| fe.vad_min_event_threshold | Length in ms of silence or speech to see before event is created | int | 300 |
+| fe.use_start_pointer | Use energy vad output to gate what frames are processed | bool | 0 |
+| fe.ivector-extraction-config | i-vector extraction config | path string | "" |
+| fe.ivector_extractor_info.use_most_recent_ivector | Uses the most recent i-vector available when set. May slightly improve accuracy but has the drawback results will be non-deterministic because features will change based on how fast audio was pushed.  Use only when WER gain is significant. | bool | 0 |
+| fe.ivector_use_ivectors | Enable iVector use for adaptation | bool | 0 |
+| fe.ivector_extractor_info.greedy_ivector_extractor | If true, use greedy iVector extraction | bool | 0 |
+| fe.ivector_lda_matrix | Filename of LDA matrix, e.g. final.mat; used for iVector extraction. | path string | "" |
+| fe.ivector_global_cmvn_stats | (Extended) filename for global CMVN stats only used for iVector extraction | path string | "" |
+| fe.ivector_cmvn_config | Configuration file for online CMVN features only used for iVector extraction | path string | "" |
+| fe.ivector_splice_config | Configuration file for frame splicing only used for iVector extraction | path string | "" |
+| fe.ivector_diag_ubm | Filename of diagonal UBM used to obtain posteriors for iVector extraction | path string | "" |
+| fe.ivector_extractor | Filename of iVector extractor | path string | "" |
+| fe.ivector_period | Frequency with which we extract iVectors for neural network adaptation | int | 10 |
+| fe.ivector_num_gselect | Number of Gaussians to select for iVector extraction | int | 5 |
+| fe.ivector_min_post | Threshold for posterior pruning in iVector extraction | float | 0.025 |
+| fe.ivector_posterior_scale | Scale for posteriors in iVector extraction (may be viewed as inverse of prior scale) | float | 0.1 |
+| fe.ivector_max_count | Maximum data count we allow before we start scaling the stats down (if nonzero). | float | 100 |
+| fe.ivector_use_most_recent_ivector | Always use most recent available i-vector, rather than the one for the designated frame.  Use with care as it leads to non-deterministic behavoir because features change with the audio delivery rate. | bool | 0 |
+| fe.ivector_greedy_extractor | 'read ahead' as many frames as we currently have available when extracting the i-vector. | bool | 0 |
+| fe.ivector_max_remembered_frames | The maximum number of frames of adaptation history that we carry through o later utterances of the same speaker. Set to 0 to remember all frames. Remembering all frames may be necessary to resolve issues when fe.use_silence_weighting is active. | int | 1000 |
+| fe.use_silence_weighting | Enable silence weighting for adaptation.  Requires fe.ivector_use_ivector=1. | bool | 0 |
+| fe.ivector_frame_limit | The number of frames at the beginning of a stream that will be used for i-vector estimation. After this number of frames is reached the i-vector will remain contant for the rest of the audio stream.  A value of -1 will use all frames in the stream, and a value of 0 will force all i-vectors to contain only zero values. | int | -1 |
+| fe.ivector_skip_period | If set (value is >1), only 1 of every fe.ivector_skip_period frames are used to accumulate and potentially estimate i-vectors. When this parameter is used fe.ivector_period should be a multiple of fe.ivector_skip_period or the i-vector will be re-estimated less than expected.  If both fe.ivector_frame_limit is >0 and fe.ivector_skip_period is set (>1), the i-vector frame skipping only happens after the first fe.ivector_frame_limit are processed. | int | -1 |
+| fe.silence_weighting_phones | List of integer ids of silence phones, separated by colons (or commas).  Data that (according to the traceback of the decoder) corresponds to these phones will be downweighted by fe.silence_weighting_weight. | string | "" |
+| fe.silence_weighting_weight | Weighting factor for frames that the decoder trace-back identifies as silence; only relevant if the fe.silence_weighting_phones option is set. | float | 1.0 |
+| fe.silence_weighing_max_state_duration | Maximum allowed duration of a single transition-id; runs with durations longer than this will be weighted down to the silence-weight. | float | -1 |
+| fe.get_pitch | If true, extract pitch, NCCF pairs for each frame. | bool | 0 |
+| fe.min_pitch | Minimum pitch (F0) to search for, in Hz. | float | 50 |
+| fe.max_pitch | Maximum pitch (F0) to search for, in Hz. | float | 400 |
+| fe.soft_min_pitch | Minimum pitch (F0), applied in soft way. Must not exceed fe.min_pitch. | float | 10 |
+| fe.penalty_factor | Cost factor for F0 change. | float | 0.1 |
+| fe.lowpass_cutoff | Cufoff frequency for lowpass filter, in Hz. | float | 1000 |
+| fe.resample_freq | Frequency that we downsample the signal to. Must be more than twice the lowpass-cutoff. | float | 4000 |
+| fe.delta_pitch | Smallest relative change in pitch that our algorithm measures | float | 0.005 |
+| fe.nccf_ballast | Increasing this factor reduces NCCF for quiet frames | float | 7000 |
+| fe.lowpass_filter_width | Integer that determines filter width of lowpass filter, more gives sharper filter | int | 1 |
+| fe.upsample_filter_width | Integer that determines filter width when upsampling NCCF | int | 5 |
+| fe.max_frames_latency | Max number of frames of latency to allow pitch tracking to introduce into the feature processing | int | 0 |
+
+
+
+#### Recognizer options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| model.type | The type of model, default is asr (options are "asr" or "keyword" | string | "asr" |
+| recognizer.log_trace | If true, print the trace of the recognizer's steps to the logger | bool | 0 |
+| recognizer.long_running | Set to 1 if the recognizer is expected to process more than a few minutes of audio.  This option makes the metrics timeline track aggregates instead of individual events so memory usage is bounded. | bool | 0 |
+| recognizer.dump_audio_path | Path where recognizers should save audio input for use in troubleshooting, empty disables dumping audio | path string | "" |
+
+
+
+#### Results options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| results.partial_results.emit_frequency_frames | When set to a positive number N, the decoder will look for a partial result every N frames.  Partial results is off if set to <= 0. | int | -1 |
+| results.nbest_generation_strategy | nbest generation algorithm. May be empty or 'lattice'. If it is empty, we will not generate an nbest. If it is 'lattice', we will generate the nbest from the lattice. | string | "" |
+| results.nbest | Nbest value; if set to N, generate 0-N results | int | 1 |
+| results.word_boundary_filepath | file needed to align words with audio frames in order to obtain timestamps (word_boundary.int) | path string | "" |
+| results.build_cnet | If true, build the confusion network | bool | 0 |
+| results.emit_cnet | If true, include the cnet in the output | bool | 0 |
+| results.mbr_decoding | If true, do the mbr_decoding when creating the cnet | bool | 1 |
+| results.nbest_results_type | Should we emit the nbest results or not; null string for no nbest result; cnet for building from cnet | string | "" |
+| results.time_align_cnet | If true, align the compact lattice for cnet building | bool | 1 |
+| results.calculate_perplexity | If true, calculate perplexity | bool | 0 |
+| results.perplexity_fst_filepath | filepath for the fst used to calculate perplexity | path string | "" |
+| results.max_mem | Max memory used in lattice determinization | int | 5000000 |
+| results.emit_metrics | If true, emit metrics for this recognizer | bool | 1 |
+| results.hmm_input_symbol_path | filepath for text based input symbol table of HMM (HCLG) | path string | "" |
+| results.emit_clat_result |  If true, emit a result from the clat (which contains info about phoneme timestamps, but not confidence) | bool | 0 |
+| results.hmm_input_symbol_path | filepath for text based input symbol table of HMM (HCLG) | path string | "" |
+| results.collect_energy |  If true, include the energy from all frames in the results payload | bool | 0 |
+| results.collect_pitch |  If true, include the pitch from all frames in the results payload | bool | 0 |
+| results.collect_posteriors | If true, include the AM posteriors from all frames in the results payload | bool | 0 |
+
+
+
+#### Scorer options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| am-compatibility-id | The parameter that tells us the compatibility of different models for loading speaker adaptation stats. If the compatibility info of the adaptation and the model matches, we should be able to load the adaptation stats for our model. The id-giving process should be done carefully to avoid naming collisions | string | "unknown" |
+| scorer.scorer_type | type of scorer we use during acoustic scoring | string | "kaldi-mlp" |
+| scorer.quantization_seg_length | Length of the quantized segment for quantized_segmented scorer to use | int | 4 |
+| scorer.acoustic_model_filepath | filepath of the acoustic model to use for scoring | path string | "" |
+| scorer.acoustic-scale | scales the acoustic models scores by this number | float | 0.1 |
+| scorer.skip_num_frames | The number of batch size for frames for which only one will be scored; negative number to disable frame skipping | int | -1 |
+| scorer.frame_subsampling_factor | Frame subsampling factor. (Will usually be 1 except for chain models) | int | 1 |
+| scorer.extra_left_context_initial | Extra left context to use at the first frame of an utterance (note: this will just consist of repeats of the first frame, and should not usually be necessary) | int | 0 |
+| scorer.frames_per_chunk | Number of frames in each chunk that is separately evaluated by the neural net.  Measured before any subsampling, if the --frame-subsampling-factor options is used (i.e. counts input frames).  This is only advisory (may be rounded up if needed). | int | 20 |
+
+
+
+#### Search options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| search.decode_fst_type | Type of decode-fst. | string | "vector_fst" |
+| search.decode_fst_filepath | filepath of the fst to use for decoding (HCLG.fst) | path string | "" |
+| search.decoder_type | type of decoder to use during search | string | "kaldi-lattice" |
+| search.output_symbol_table_filepath | filepath to output symbol table | path string | "" |
+| search.max_active | maximum number of toks during decoding, enforced between PNE and PE | float | 7000 |
+| search.beam | decoder's beam | float | 15.0 |
+| search.lattice_beam | result building lattice beam | float | 6.0 |
+| search.hcl_fst_filepath | filepath of the HCL fst for decoding (HCL.fst), to be used with dynamic decoding | path string | "" |
+| search.g_fst_filepath | filepath of the fst we'll use for decoding (G.fst), to be used with dynamic decoding | path string | "" |
+| search.on_separate_thread | If true, perform search work on a separate thread from the scoring work | bool | 0 |
+
+
+
+#### Speech Verification options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| speech_verification.lexicon_filepath | filepath to lexicon for speech verification | path string | "" |
+| speech_verification.vowels_filepath | filepath to list of vowel phones for speech verification | path string | "" |
+| speech_verification.align_vowels | If true, favor aligning vowels in the reference to vowels in the hypothesis list. Should also set vowels_filepath. | bool | 0 |
+| speech_verification.max_candidate_prons | max number of prons to consider for speech verification | int | 250 |
+| speech_verification.cutoff_filepath | filepath to per-pron thresholds (the confidence threshold for the pron being 'correct') for speech verification | path string | "" |
+| speech_verification.stress_regressor_filepath | filepath to SVM model used to score stress | path string | "" |
+| speech_verification.svm_scale_filepath | filepath to scale used on input features to the SVM model | path string | "" |
+| speech_verification.output_svm_feature_vector | If true, output feature vectors for stress scoring | bool | 0 |
+| speech_verification.cnet_link_threshold | The combined scores of the candidates in a link must exceed this threshold to be included in the alignment | float | 0.0 |
+| speech_verification.noise_phone_string | Colon-delimited list of phone IDs (corresponding to output symbol IDs) to exclude in alignment | string | "" |
+
+
+
+#### ASR model specific options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| results.emit_confidence | If true, emit word level confidences for nbest result list | bool | 0 |
+| results.tokens_nbest_redundant | The CSV list which contains strings that are considered redundant for the purpose of nbest results | string | "\<eps>,[noise],\<s>" |
+| results.emit_timestamps | Whether to produce word timestamps | bool | 0 |
+| results.scale_speech_posteriors | If true, scale up speech posteriors for better results with limited grammars and very similar phrases | bool | 0 |
+| results.nonspeech_tokens | The csv list which contains token strings that are considered to be non-speech | string | "\<eps>,\#0,\<VOCAL_NOISE>,\<NON_SPEECH_NOISE>,SIL,~SIL,sil,~sil" |
+
+
+
+#### Keyword model specific options
+| Option | Description | Type | Default Value |
+| --- | --- | --- | --- |
+| keyword.g2p_model | Path to the grapheme-to-phoneme fst | path string | "" |
+| keyword.word_symbol_table | Path to the word symbol table | path string | "" |
+| keyword.phone_symbol_table | Path to the phone symbol table | path string | "" |
+| keyword.context_dependency | Path to the context dependency (tree) file | path string | "" |
+| keyword.lexicon | Path to the context dependency lexicon text file | path string | "" |
+| keyword.lm_keyword_cost | Cost (neg-log-prob) of taking the keyword path | float | 0.0 |
+| keyword.lm_background_cost | Cost (neg-log-prob) of taking the background path | float | 0.0 |
+| keyword.lm_background_tokens | Comma-separated list of background word tokens (e.g. '\<UNK>,\<VOCAL_NOISE>') | string | "" |
+| keyword.lex_sil_prob | Probability of optional silence in the lexicon | float | 0.5 |
+| keyword.lex_sil_phone | Silence phone token | string | "SIL" |
+| keyword.confidence_cost_map | Path to file containing JSON object that describes mappings from confidence values to keyword path costs | path string | "" |
+| results.emit_confidence | Should we enable emitting word level confidences for nbest result list? | bool | 1 |
+| results.tokens_nbest_redundant | The CSV list which contains strings that are considered redundant for the purpose of nbest results | string | "\<eps>,[noise],\<s>,\<unk>" |
+| results.emit_timestamps | Whether to produce word timestamps | bool | 1 |
+| results.scale_speech_posteriors | Should speech posteriors be scaled up for better results with limited grammars and very similar phrases? | bool | 1 |
+| results.nonspeech_tokens | The csv list which contains token strings that are considered to be non-speech | string | "\<UNK>,\<eps>,\#0,\<VOCAL_NOISE>,\<NON_SPEECH_NOISE>,SIL,~SIL,sil,~sil" |


### PR DESCRIPTION
What do you guys think about moving/copying the C API documentation to the client repo so we can point customers to it?

BTW, while we can take this opportunity to comment on the contents of these documents, I should point out that I didn't write any of them, I just moved them from the old wiki and made some minor edits, so I won't necessarily be able to answer detailed questions.